### PR TITLE
Fixes issues with configuring 8 analog channels

### DIFF
--- a/di2008/instrument.py
+++ b/di2008/instrument.py
@@ -239,7 +239,8 @@ class AnalogPort(Port):
         filter_value = filter_types.index(filter.lower())
 
         self.configuration = configuration
-        self.commands += [f'filter {channel} {filter_value}',
+
+        self.commands += [f'filter {channel-1} {filter_value}',
                           f'dec {filter_decimation}']
 
     @property


### PR DESCRIPTION
Fixes #8   - When using commands, channels are 0 based. This was sending 1 based channel data leading to the instrument hanging when configuring filters for 8 channels.

